### PR TITLE
fix(memory): align size for std::aligned_alloc in CPUAllocator

### DIFF
--- a/src/mat/origin/memory/allocator.cpp
+++ b/src/mat/origin/memory/allocator.cpp
@@ -35,7 +35,8 @@ namespace origin
 void *CPUAllocator::allocate(size_t size)
 {
     // 为CPU分配对齐的内存
-    void *ptr = std::aligned_alloc(MEMORY_ALIGNMENT, size);
+    size_t aligned_size = (size + MEMORY_ALIGNMENT - 1) & ~(MEMORY_ALIGNMENT - 1);
+    void *ptr           = std::aligned_alloc(MEMORY_ALIGNMENT, aligned_size);
     if (ptr == nullptr)
     {
         throw std::bad_alloc();


### PR DESCRIPTION
## Summary
- `std::aligned_alloc(alignment, size)` requires `size` to be a multiple of `alignment`, otherwise the behavior is undefined per C17/C++17 spec.
- The CUDA allocator already rounds up size correctly (line 65), but the CPU allocator doesn't — fixed by applying the same round-up logic.

- [x] Verify memory allocation works for non-power-of-2 sizes